### PR TITLE
Clean up images when PRs are closed

### DIFF
--- a/.azure-devops/acr_image_purge.sh
+++ b/.azure-devops/acr_image_purge.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+set -e
+
+
+function show_usage() {
+	echo
+	echo "acr_image_purge.sh"
+	echo
+	echo "Sets up auto-purging of images"
+	echo
+	echo -e "\t--registry-name\t(Required)The name of the ACR containing the images to protect/purge"
+	echo
+}
+
+
+# Set default values here
+registry_name=""
+
+
+# Process switches:
+while [[ $# -gt 0 ]]
+do
+	case "$1" in
+		--registry-name)
+			registry_name=$2
+			shift 2
+			;;
+		*)
+			echo "Unexpected '$1'"
+			show_usage
+			exit 1
+			;;
+	esac
+done
+
+
+if [[ -z $registry_name ]]; then
+	echo "--registry-name must be specified"
+	show_usage
+	exit 1
+fi
+
+
+
+# Protect 'latest' tags to improve general build times
+image_names=$(az acr repository list --name $registry_name -o tsv)
+
+
+for image_name in ${image_names[@]}; 
+do
+	echo "Preventing delete for $image_name:latest"
+	az acr repository update \
+			--name $registry_name \
+			--image $image_name:latest \
+			--delete-enabled false \
+			--write-enabled true
+done
+
+
+PURGE_CMD="acr purge --filter '.*:pr-[0-9a-fA-F]+' --ago 4d --untagged"
+
+az acr task create --name prTagPruneTask \
+  --cmd "$PURGE_CMD" \
+  --registry $registry_name \
+  --schedule "4 18 * * *" \
+  --context /dev/null \
+  --base-image-trigger-enabled false

--- a/.github/workflows/clean_tags.sh
+++ b/.github/workflows/clean_tags.sh
@@ -39,7 +39,25 @@ if [[ -z $tag ]]; then
 	exit 1
 fi
 
-image_name="stuartleeks/devcontainer-build-run/tests/dockerfile-context"
+image_names=(
+	"devcontainer-build-run-devcontainer"
+	"devcontainer-build-run/tests/run-args"
+	"devcontainer-build-run/tests/build-args"
+	"devcontainer-build-run/tests/dockerfile-context"
+	"devcontainer-build-run/tests/feature-docker-from-docker"
+	"devcontainer-build-run/tests/docker-from-docker-non-root"
+	"devcontainer-build-run/tests/docker-from-docker-root"
+	"devcontainer-build-run/tests/skip-user-update"
+)
 
-tag_id=$( curl -s  -H "Authorization: Bearer $GITHUB_TOKEN"  -H "Accept: application/vnd.github.v3+json"   https://api.github.com/users/stuartleeks/packages/container/devcontainer-build-run%2ftests%2fdockerfile-context/versions | jq -r '.[] | select(.metadata.container.tags | index("pr-119")) | .id')
-echo $tag_id
+for image_name in ${image_names[@]}; 
+do
+	escaped_image_name=$(echo ${image_name} | sed "s/\//%2f/g")
+	version_id=$( curl -s  -H "Authorization: Bearer $GITHUB_TOKEN"  -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/stuartleeks/packages/container/$escaped_image_name/versions" | jq -r ".[] | select(.metadata.container.tags | index(\"${tag}\")) | .id")
+	if [[ -n $version_id ]]; then
+		echo "Found version '$version_id' for '$image_name:$tag' - deleting..."
+	curl -s -X DELETE -H "Authorization: Bearer $GITHUB_TOKEN"  -H "Accept: application/vnd.github.v3+json" "https://api.github.com/users/stuartleeks/packages/container/$escaped_image_name/versions/$version_id"
+	else
+		echo "Tag '$tag' not found for '$image_name:$tag' - skipping"
+	fi
+done

--- a/.github/workflows/pr-closed.yml
+++ b/.github/workflows/pr-closed.yml
@@ -1,0 +1,25 @@
+name: pr_closed
+
+on:
+  pull_request:
+    types: [closed]
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+
+jobs:
+
+  pr_closed:
+    name: PR Closed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - name: Clean GitHub container images for PR
+        env:
+          PR_IMAGE_TAG: pr-${{ github.event.pull_request.number }}
+        run:
+          ./github/workflows/clean_tags.sh --tag $PR_IMAGE_TAG


### PR DESCRIPTION
Various images are pushed to the container registry during PR build testing - add a workflow to clean images for a PR when it is closed